### PR TITLE
Manage the case when a loader is part of the path

### DIFF
--- a/packages/roc-package-webpack-node-dev/src/builder/index.js
+++ b/packages/roc-package-webpack-node-dev/src/builder/index.js
@@ -38,8 +38,10 @@ export default () => ({ previousValue: rocBuilder }) => (target) => {
                         return callback();
                     }
 
-                    // If a normal node_module mark it as external
-                    if (/^[a-zA-Z\-0-9]{1}.*$/.test(request)) {
+                    // If a normal node_module mark it as external and manage
+                    // Webpack loaders that might be a part of the path
+                    const resourcePath = request.split('!').pop();
+                    if (/^[a-zA-Z\-0-9]{1}.*$/.test(resourcePath)) {
                         return callback(null, true);
                     }
 


### PR DESCRIPTION
Fixes problem with less-loader which added a loader in the path.
This is managed in the same way as Webpack does this internally.
We should probably use some internal function in Webpack to do this in the future.
