### PR TITLE
Add support for V8 inspector

### DIFF
--- a/extensions/roc-package-webpack-node-dev/src/config/roc.config.js
+++ b/extensions/roc-package-webpack-node-dev/src/config/roc.config.js
@@ -4,10 +4,11 @@ export default {
             watch: [
                 'roc.config.js',
             ],
-            inspect: false,
-            'debug-brk': false,
+            inspect: {
+                enable: false,
+                'debug-brk': false,
+            },
         },
-
         build: {
             targets: ['node'],
         },

--- a/extensions/roc-package-webpack-node-dev/src/config/roc.config.js
+++ b/extensions/roc-package-webpack-node-dev/src/config/roc.config.js
@@ -4,6 +4,8 @@ export default {
             watch: [
                 'roc.config.js',
             ],
+            inspect: false,
+            'debug-brk': false,
         },
 
         build: {

--- a/extensions/roc-package-webpack-node-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-webpack-node-dev/src/config/roc.config.meta.js
@@ -6,6 +6,20 @@ import {
     required,
 } from 'roc/validators';
 
+function v8InspectorIsSupported(value, info) {
+    const booleanCheck = isBoolean(value, info);
+    if (booleanCheck !== true) {
+        return booleanCheck;
+    }
+
+    const nodeMajorVersion = process.version.substr(1, 1);
+    if (value === true && nodeMajorVersion < 6) {
+        return 'The V8 inspector is only supported on Node.js v6 and above!';
+    }
+
+    return true;
+}
+
 export default {
     settings: {
         dev: {
@@ -16,7 +30,7 @@ export default {
             inspect: {
                 enable: {
                     description: 'Enable V8 inspector',
-                    validator: isBoolean,
+                    validator: v8InspectorIsSupported,
                 },
                 'debug-brk': {
                     description: 'Break on first line when V8 inspector is enabled',

--- a/extensions/roc-package-webpack-node-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-webpack-node-dev/src/config/roc.config.meta.js
@@ -14,12 +14,14 @@ export default {
                 validator: required(oneOf(isPath, isArray(isPath))),
             },
             inspect: {
-                description: 'Enable V8 inspector',
-                validator: isBoolean,
-            },
-            'debug-brk': {
-                description: 'Break on first line when V8 inspector is enabled',
-                validator: isBoolean,
+                enable: {
+                    description: 'Enable V8 inspector',
+                    validator: isBoolean,
+                },
+                'debug-brk': {
+                    description: 'Break on first line when V8 inspector is enabled',
+                    validator: isBoolean,
+                },
             },
             build: {
                 targets: {

--- a/extensions/roc-package-webpack-node-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-webpack-node-dev/src/config/roc.config.meta.js
@@ -1,6 +1,7 @@
 import {
     isArray,
     isPath,
+    isBoolean,
     oneOf,
     required,
 } from 'roc/validators';
@@ -11,6 +12,14 @@ export default {
             watch: {
                 description: 'Files/folders that should trigger a restart of the server.',
                 validator: required(oneOf(isPath, isArray(isPath))),
+            },
+            inspect: {
+                description: 'Enable V8 inspector',
+                validator: isBoolean,
+            },
+            'debug-brk': {
+                description: 'Break on first line when V8 inspector is enabled',
+                validator: isBoolean,
             },
             build: {
                 targets: {

--- a/extensions/roc-package-webpack-node-dev/src/watcher/server.js
+++ b/extensions/roc-package-webpack-node-dev/src/watcher/server.js
@@ -84,7 +84,17 @@ export default function server(compiler) {
                 ROC_NODE_DEV_ENTRY: bundlePath,
             };
             // env - use it for the entry file
-            serverProcess = childProcess.fork(require.resolve('./wrapper'), { env });
+
+            const execArgv = process.execArgv;
+            if (settings.inspect) {
+                execArgv.push('--inspect');
+            }
+            if (settings['debug-brk']) {
+                execArgv.push('--debug-brk');
+            }
+
+            serverProcess = childProcess.fork(require.resolve('./wrapper'),
+                { env, execArgv });
 
             // Make sure or node process is terminated when the main process is
             process.on('exit', () => stopServer());

--- a/extensions/roc-package-webpack-node-dev/src/watcher/server.js
+++ b/extensions/roc-package-webpack-node-dev/src/watcher/server.js
@@ -86,10 +86,10 @@ export default function server(compiler) {
             // env - use it for the entry file
 
             const execArgv = process.execArgv;
-            if (settings.inspect) {
+            if (settings.inspect.enable) {
                 execArgv.push('--inspect');
             }
-            if (settings['debug-brk']) {
+            if (settings.inspect['debug-brk']) {
                 execArgv.push('--debug-brk');
             }
 


### PR DESCRIPTION
This adds support for the new experimental V8 Inspector. It can be
enabled with the setting `--dev-inspect`.

It has to be enabled here since we're creating a new node process.

See https://nodejs.org/api/debugger.html#debugger_v8_inspector_integration_for_node_js