### PR TITLE
Add hook for extending list of possible Roc targets targeting node

### DIFF
--- a/extensions/roc-package-webpack-node-dev/docs/Hooks.md
+++ b/extensions/roc-package-webpack-node-dev/docs/Hooks.md
@@ -16,6 +16,7 @@
 * [roc-package-webpack-node-dev](#roc-package-webpack-node-dev)
   * [dev-process-created](#dev-process-created)
   * [dev-process-stopping](#dev-process-stopping)
+  * [get-webpack-node-targets](#get-webpack-node-targets)
 * [roc-plugin-start](#roc-plugin-start)
   * [get-potential-target](#get-potential-target)
   * [register-runtime](#register-runtime)
@@ -149,6 +150,13 @@ __Expected return value:__ _Nothing_
 | Name          | Description                               | Type | Required | Can be empty |
 | ------------- | ----------------------------------------- | ---- | -------- | ------------ |
 | serverProcess | The server process that is being stopped. |      | No       |              |
+
+### get-webpack-node-targets
+
+Used to inform which targets should be considered Webpack "node" targets. Actions should concat the previousValue to build the complete value.
+
+__Initial value:__ `["node"]`  
+__Expected return value:__ `Array(String)`
 
 ## roc-plugin-start
 

--- a/extensions/roc-package-webpack-node-dev/src/roc/index.js
+++ b/extensions/roc-package-webpack-node-dev/src/roc/index.js
@@ -1,4 +1,5 @@
 import { lazyFunctionRequire } from 'roc';
+import { isString, isArray } from 'roc/validators';
 
 import config from '../config/roc.config.js';
 import meta from '../config/roc.config.meta.js';
@@ -45,6 +46,12 @@ export default {
                     description: 'The server process that is being stopped.',
                 },
             },
+        },
+        'get-webpack-node-targets': {
+            description: 'Used to inform which targets should be considered Webpack "node" targets. ' +
+                'Actions should concat the previousValue to build the complete value.',
+            initialValue: ['node'],
+            returns: isArray(isString),
         },
     },
 };

--- a/extensions/roc-package-webpack-node-dev/src/webpack/index.js
+++ b/extensions/roc-package-webpack-node-dev/src/webpack/index.js
@@ -3,8 +3,11 @@ import path from 'path';
 import { getSettings } from 'roc';
 import webpack from 'webpack';
 
+import { invokeHook } from '../roc/util';
+
 export default ({ previousValue: webpackConfig }) => (target) => {
-    if (target === 'node') {
+    const nodeTargets = invokeHook('get-webpack-node-targets');
+    if (nodeTargets.indexOf(target) !== -1) {
         return () => {
             const newWebpackConfig = { ...webpackConfig };
             const buildSettings = getSettings('build');


### PR DESCRIPTION
This change adds support for 'static' build target to roc-package-web-app
by allowing to reuse webpack config from 'node' target in 'static' target.